### PR TITLE
Upgraded to Ubuntu 17.10 and removed redundant apache lib

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:15.04
+FROM ubuntu:17.10
 
 # Update Ubuntu
 RUN apt-get update ; apt-get dist-upgrade -y -qq 
 
 # Install Apache + modules
-RUN apt-get install -y -qq libapache2-mod-proxy-html apache2 && \
+RUN apt-get install -y -qq apache2 && \
     a2enmod proxy proxy_http proxy_ajp rewrite deflate headers proxy_balancer proxy_connect proxy_html lbmethod_byrequests && \
     mkdir /var/lock/apache2 && mkdir /var/run/apache2
 


### PR DESCRIPTION
The same change should be applied to the consul dns demo.